### PR TITLE
i18n: replace hardcoded launch tooltip strings

### DIFF
--- a/src/components/features/mods-library.tsx
+++ b/src/components/features/mods-library.tsx
@@ -1143,24 +1143,24 @@ export function ModsLibrary() {
 
   // Determine launch button state and tooltip
   let launchDisabled = true
-  let launchTooltip = "Install folder not set"
-  
+  let launchTooltip = t("dashboard_install_folder_not_set")
+
   const isRunning = launchStatus.data?.running ?? false
   const isLaunching = launchMutation.isPending
-  
+
   if (installFolder) {
     if (binaryVerification.isLoading) {
       launchDisabled = true
-      launchTooltip = "Verifying game files..."
+      launchTooltip = t("dashboard_verifying_game_files")
     } else if (!binaryVerification.data?.ok) {
       launchDisabled = true
-      launchTooltip = binaryVerification.data?.reason || "Game binary not found"
+      launchTooltip = binaryVerification.data?.reason || t("dashboard_game_binary_not_found")
     } else if (isRunning) {
       launchDisabled = true
-      launchTooltip = "Game is running"
+      launchTooltip = t("dashboard_game_is_running")
     } else if (isLaunching) {
       launchDisabled = true
-      launchTooltip = "Launching..."
+      launchTooltip = t("dashboard_launching")
     } else {
       launchDisabled = false
       launchTooltip = ""

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,6 +147,7 @@
   "dashboard_verifying_game_files": "Verifying game files...",
   "dashboard_game_binary_not_found": "Game binary not found",
   "dashboard_game_is_running": "Game is running",
+  "dashboard_launching": "Launching...",
   "dashboard_profiles_and_sync": "Profiles & Sync",
   "dashboard_current_profile": "Current Profile",
   "dashboard_import_profile_code": "Import Profile Code",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -147,6 +147,7 @@
     "dashboard_verifying_game_files": "正在验证游戏文件...",
     "dashboard_game_binary_not_found": "未找到游戏可执行文件",
     "dashboard_game_is_running": "游戏正在运行",
+    "dashboard_launching": "正在启动...",
     "dashboard_profiles_and_sync": "配置存档与同步",
     "dashboard_current_profile": "当前配置存档",
     "dashboard_import_profile_code": "导入配置存档代码",

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -147,6 +147,7 @@
     "dashboard_verifying_game_files": "正在驗證遊戲檔案...",
     "dashboard_game_binary_not_found": "未找到遊戲執行檔",
     "dashboard_game_is_running": "遊戲正在執行",
+    "dashboard_launching": "正在啟動...",
     "dashboard_profiles_and_sync": "設定檔與同步",
     "dashboard_current_profile": "目前設定檔",
     "dashboard_import_profile_code": "匯入設定檔代碼",


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in launch button tooltips with `t()` i18n calls
- Add missing `dashboard_launching` key to en.json, zh_CN.json, zh_TW.json

## Changes
- `mods-library.tsx`: Use `t("dashboard_*")` for all tooltip messages
- `en.json`: Add `"dashboard_launching": "Launching..."`
- `zh_CN.json`: Add `"dashboard_launching": "正在启动..."`
- `zh_TW.json`: Add `"dashboard_launching": "正在啟動..."`

## Test plan
- [ ] Switch language to Chinese and verify launch tooltips display correctly
- [ ] Verify all tooltip states work (not set, verifying, running, launching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)