### PR TITLE
ci: add GitHub Actions workflows for multi-platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
 
   build:
     name: Build (${{ matrix.os }})
-    needs: lint-and-typecheck
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm lint
+
+  build:
+    name: Build (${{ matrix.os }})
+    needs: lint-and-typecheck
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: mac
+            artifact-name: mac-arm64
+          - os: windows-latest
+            platform: win
+            artifact-name: win-x64
+          - os: ubuntu-latest
+            platform: linux
+            artifact-name: linux-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build:electron
+
+      - run: pnpm dist:${{ matrix.platform }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}-pr-${{ github.event.pull_request.number }}
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/*.exe
+            release/*.AppImage
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,167 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is-prerelease: ${{ steps.version.outputs.is-prerelease }}
+    steps:
+      - name: Parse version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" =~ (alpha|beta|rc) ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+  lint-and-typecheck:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm lint
+
+  build-mac:
+    name: Build macOS (arm64)
+    needs: [prepare, lint-and-typecheck]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build:electron
+
+      - run: pnpm dist:mac
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mac-arm64
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/latest-mac.yml
+
+  build-windows:
+    name: Build Windows (${{ matrix.arch }})
+    needs: [prepare, lint-and-typecheck]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build:electron
+
+      - run: pnpm dist:win-${{ matrix.arch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: win-${{ matrix.arch }}
+          path: |
+            release/*.exe
+            release/latest.yml
+
+  build-linux:
+    name: Build Linux (${{ matrix.arch }})
+    needs: [prepare, lint-and-typecheck]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build:electron
+
+      - run: pnpm dist:linux-${{ matrix.arch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: |
+            release/*.AppImage
+            release/latest-linux.yml
+
+  release:
+    name: Create GitHub Release
+    needs: [prepare, build-mac, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: r2modmanplusplus v${{ needs.prepare.outputs.version }}
+          prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
+          generate_release_notes: true
+          files: |
+            artifacts/**/*.dmg
+            artifacts/**/*.zip
+            artifacts/**/*.exe
+            artifacts/**/*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
   build-mac:
     name: Build macOS (arm64)
-    needs: [prepare, lint-and-typecheck]
+    needs: prepare
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   build-windows:
     name: Build Windows (${{ matrix.arch }})
-    needs: [prepare, lint-and-typecheck]
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +112,7 @@ jobs:
 
   build-linux:
     name: Build Linux (${{ matrix.arch }})
-    needs: [prepare, lint-and-typecheck]
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [prepare, build-mac, build-windows, build-linux]
+    needs: [prepare, lint-and-typecheck, build-mac, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "preview:electron": "electron-vite preview",
     "dist": "pnpm build:electron && electron-builder",
     "dist:win": "pnpm build:electron && electron-builder --win",
-    "dist:mac": "pnpm build:electron && electron-builder --mac"
+    "dist:mac": "pnpm build:electron && electron-builder --mac",
+    "dist:linux": "pnpm build:electron && electron-builder --linux",
+    "dist:win-x64": "pnpm build:electron && electron-builder --win --x64",
+    "dist:win-arm64": "pnpm build:electron && electron-builder --win --arm64",
+    "dist:linux-x64": "pnpm build:electron && electron-builder --linux --x64",
+    "dist:linux-arm64": "pnpm build:electron && electron-builder --linux --arm64"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
@@ -87,21 +92,22 @@
       "out/**/*",
       "package.json"
     ],
+    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        { "target": "dmg", "arch": ["arm64"] },
+        { "target": "zip", "arch": ["arm64"] }
       ],
       "category": "public.app-category.utilities"
     },
     "win": {
       "target": [
-        "nsis"
+        { "target": "nsis", "arch": ["x64", "arm64"] }
       ]
     },
     "linux": {
       "target": [
-        "AppImage"
+        { "target": "AppImage", "arch": ["x64", "arm64"] }
       ],
       "category": "Utility"
     }


### PR DESCRIPTION
## Summary
- Add CI workflow for pull requests (lint, typecheck, build verification)
- Add Release workflow for tag-based releases with auto-generated release notes
- Support multi-platform builds: macOS (arm64), Windows (x64/arm64), Linux (x64/arm64)
- Auto-detect pre-release versions (alpha, beta, rc) from tags

## Build Matrix

| Platform | Architecture | Runner |
|----------|--------------|--------|
| macOS | arm64 | macos-latest |
| Windows | x64 | windows-latest |
| Windows | arm64 | windows-latest |
| Linux | x64 | ubuntu-latest |
| Linux | arm64 | ubuntu-latest |

## Workflows

### CI (on pull_request)
1. Lint & Typecheck
2. Build for macOS, Windows, Linux (parallel)
3. Upload artifacts (7-day retention)

### Release (on tag push)
1. Parse version from tag
2. Lint & Typecheck
3. Build all platforms/architectures (parallel)
4. Create GitHub Release (pre-release if alpha/beta/rc)

## Test plan
- [ ] Create a test PR to verify CI workflow
- [ ] Push a pre-release tag (e.g., `v0.0.2-alpha.1`) to test release workflow
- [ ] Push a stable tag (e.g., `v0.0.2`) to verify non-prerelease behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)